### PR TITLE
tpdequeue()/tpenqueue(). Don't use undocumented PyDescr_NAME. Minor c…

### DIFF
--- a/demo/client.py
+++ b/demo/client.py
@@ -16,4 +16,3 @@ if __name__ == '__main__':
     t.tpcall('MEMPUT', {'KEY': ['B', 'C'], 'VALUE': ['b', 'c']})
     _, _, data = t.tpcall('MEMGET', {'KEY': ['B', 'C', 'A']})
     assert data['VALUE'] == ['b', 'c', 'a']
-

--- a/demo/ecb.py
+++ b/demo/ecb.py
@@ -28,7 +28,6 @@ class Server:
             self._rates = {}
             for r in x.findall('.//*[@currency]'):
                 self._rates[r.attrib['currency']] = float(r.attrib['rate'])
-        
         return t.tpreturn(t.TPSUCCESS, 0, {'RATE': self._rates[args['CURRENCY'][0]]})
 
     def RELOAD(self, args):


### PR DESCRIPTION
tpdequeue()/tpenqueue(). 
Don't use undocumented PyDescr_NAME, compiles for python2.7
Minor code formatting fixes.