### PR TITLE
Fix python2 compatibility.#noissue

### DIFF
--- a/src/tuxedo.cpp
+++ b/src/tuxedo.cpp
@@ -688,8 +688,11 @@ void PY(TPSVCINFO *svcinfo) {
 
     auto &&func = server.attr(svcinfo->name);
     auto &&code = func.attr("__code__");
-    long argcount = (code.attr("co_argcount") + code.attr("co_kwonlyargcount"))
-                        .cast<py::int_>();
+    long argcount = (code.attr("co_argcount")
+#if PY_MAJOR_VERSION >= 3
+                        + code.attr("co_kwonlyargcount")
+#endif
+			).cast<py::int_>();
     auto &&args = code.attr("co_varnames")[py::slice(0, argcount, 1)];
     py::dict kwargs;
     if (args.contains(py::str("name"))) {


### PR DESCRIPTION
Nesapratu, kā to nepamānījām agrāk. Testi bija bet ar nepareizu assert.
Uz python2 serveris pie izsaukuma krita ar 
142513.uldisa_control!toupper_py2.py.90675.2076141376.-2: AttributeError: 'code' object has no attribute 'co_kwonlyargcount'
142513.uldisa_control!toupper_py2.py.90675.2076141376.-2: LIBTUX_CAT:1393: WARN: tpreturn called with TPEXIT
